### PR TITLE
Fix iss156

### DIFF
--- a/R/CreateFlowchart.R
+++ b/R/CreateFlowchart.R
@@ -180,7 +180,6 @@ paste("\\def\\flowchartElements", paste(flowchart.elements, collapse = ""), "\n"
     }    
     return (tikz.print)
 }
-
 #' FormatText
 #'
 #' Read flowchart elements, insert math inline, and escape underscores. If read.from.results special formatting is conducted where newlines are removed and commas are corrected.

--- a/R/CreateFlowchart.R
+++ b/R/CreateFlowchart.R
@@ -14,7 +14,7 @@
 #' @export
 CreateFlowchart <- function(flowchart.elements = NULL, flowchart.font = NULL,
                             flowchart.file.path = "./flowchart.tex", print.tikz = TRUE,
-                            save.tikz = TRUE, compile.flowchart = TRUE, train.test.split = FALSE,
+                            save.tikz = TRUE, compile.flowchart = FALSE, train.test.split = FALSE,
                             prettify = FALSE, read.from.results = TRUE, ...)
 {
     # Get file format of flowchart.file.path


### PR DESCRIPTION
Underscores are now escaped and numbers are reformatted to math inline for both manual flowchart.elements and flowchart.elements read from results. Also, changed compiler to xelatex for both .rtex and .tex files.